### PR TITLE
[flex]: Add inspec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# flex
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.flex?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+
 # flex
 
 ## Maintainers

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+command_relative_path: '/bin/flex'

--- a/controls/flex_exists.rb
+++ b/controls/flex_exists.rb
@@ -1,0 +1,22 @@
+title 'Tests to confirm flex exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'flex')
+ 
+control 'core-plans-flex-exists' do
+  impact 1.0
+  title 'Ensure flex exists'
+  desc '
+  '
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  command_relative_path = input('command_relative_path', value: '/bin/flex')
+  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+  describe file(command_full_path) do
+    it { should exist }
+  end
+end

--- a/controls/flex_exists.rb
+++ b/controls/flex_exists.rb
@@ -7,7 +7,8 @@ control 'core-plans-flex-exists' do
   impact 1.0
   title 'Ensure flex exists'
   desc '
-  '
+  Verify flex by ensuring /bin/flex exists'
+  
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }

--- a/controls/flex_works.rb
+++ b/controls/flex_works.rb
@@ -2,20 +2,22 @@ title 'Tests to confirm flex works as expected'
 
 plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'flex')
+plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
 
 control 'core-plans-flex-works' do
   impact 1.0
   title 'Ensure flex works as expected'
   desc '
+  Verify flex by ensuring (1) its installation directory exists and (2) that
+  it returns the expected version
   '
-  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
   end
   
-  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
-  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
   describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} flex --version") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }

--- a/controls/flex_works.rb
+++ b/controls/flex_works.rb
@@ -1,0 +1,25 @@
+title 'Tests to confirm flex works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'flex')
+
+control 'core-plans-flex-works' do
+  impact 1.0
+  title 'Ensure flex works as expected'
+  desc '
+  '
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  
+  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
+  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} flex --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /flex #{plan_pkg_version}/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,9 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
-maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
-copyright: humans@habitat.sh
-copyright_email: humans@habitat.sh
+name: flex
+title: Habitat Core Plan flex
+maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+summary: InSpec controls for testing Habitat Core Plan flex
+copyright: 2019, Chef Software, Inc.
+copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 3.0.25'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,57 @@
+pkg_name=flex
+pkg_origin=core
+pkg_version=2.6.4
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="Flex is a fast lexical analyser generator. It is a tool for generating programs that perform pattern-matching on text. Flex is a free (but non-GNU) implementation of the original Unix lex program."
+pkg_license=('custom')
+pkg_upstream_url="https://www.gnu.org/software/flex/"
+pkg_source=https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz
+pkg_shasum=e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995
+pkg_deps=(core/glibc)
+pkg_build_deps=(core/coreutils core/diffutils core/patch core/make core/gcc core/m4 core/bison)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+do_prepare() {
+  CFLAGS="${CFLAGS} -D_GNU_SOURCE"
+  build_line "Updating CFLAGS=$CFLAGS"
+}
+
+do_check() {
+  # Set `LDFLAGS` for the c++ test code to find libstdc++
+  make check LDFLAGS="$LDFLAGS -lstdc++"
+}
+
+do_build() {
+  CFLAGS="${CFLAGS} -D_GNU_SOURCE"
+
+  do_default_build
+}
+
+do_install() {
+  do_default_install
+
+  install --mode 0644 COPYING "$pkg_prefix"/
+
+  # A few programs do not know about `flex` yet and try to run its predecessor,
+  # `lex`
+  ln -sv flex "$pkg_prefix/bin/lex"
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/gcc
+    core/m4
+    core/coreutils
+    core/bison
+  )
+fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,6 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} flex --version)"
+  [ "$result" = "flex ${TEST_PKG_VERSION}" ]
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
```rspec
hab pkg exec chef/inspec inspec exec /src/. --chef-license=accept -t docker://9953c9d425f0355049d8f7aa12046ace73a1793b47b226d1143048376f65f37d --input-file /src/attributes.yml

Profile: Habitat Core Plan flex (flex)
Version: 0.1.0
Target:  docker://9953c9d425f0355049d8f7aa12046ace73a1793b47b226d1143048376f65f37d

  ✔  core-plans-flex-exists: Ensure flex exists
     ✔  File /hab/pkgs/core/flex/2.6.4/20200602214726/bin/flex is expected to exist
  ✔  core-plans-flex-works: Ensure flex works as expected
     ✔  Command: `hab pkg path core/flex` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/flex` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/flex/2.6.4/20200602214726 flex --version` exit_status is expected to eq 0
     ✔  Command: `DEBUG=true; hab pkg exec core/flex/2.6.4/20200602214726 flex --version` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/flex/2.6.4/20200602214726 flex --version` stdout is expected to match /flex 2.6.4/
     ✔  Command: `DEBUG=true; hab pkg exec core/flex/2.6.4/20200602214726 flex --version` stderr is expected to be empty


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 7 successful, 0 failures, 0 skipped
+ set +x
[6][default:/src:0]# 
```